### PR TITLE
Change docker-compose to docker compose

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -14,7 +14,7 @@ We should learn a couple of core concepts before Apache APISIX work as per our n
 
 == Pre-requisites
 
-* Installed https://www.docker.com/[Docker^] and https://docs.docker.com/compose/[Docker Compose^] component.
+* Installed https://www.docker.com/[Docker^].
 * We use the https://curl.se/docs/manpage.html[curl^] command for API testing.
 You can also use other tools such as Postman for testing.
 
@@ -34,11 +34,11 @@ Switch the current directory to the apisix-docker/example path.
 cd apisix-docker/example
 ----
 
-Run the docker-compose command to install Apache APISIX.
+Run the `docker compose` command to install Apache APISIX.
 
 [source,bash]
 ----
-docker-compose -p docker-apisix up -d
+docker compose -p docker-apisix up -d
 ----
 
 == HTTP Basic Authentication


### PR DESCRIPTION
docker-compose is deprecated, its features have been merged in the [docker](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command) command itself